### PR TITLE
[fix] 일정페이지 접근 권한 로직 수정 및 외 5

### DIFF
--- a/src/components/layout/GroupDashboardLayout.tsx
+++ b/src/components/layout/GroupDashboardLayout.tsx
@@ -16,7 +16,7 @@ function GroupDashboardLayout({ children }: LayoutProps) {
       </div>
 
       {/* 높이 보정 */}
-      <div className="w-full h-0 pb-[100px]" />
+      <div className="w-full h-0 pb-14" />
     </div>
   );
 }


### PR DESCRIPTION
### Summary
일정페이지 접근 권한 로직 수정 완료
그룹 멤버 관리 기능을 전체적으로 완성
로그인/멤버 상태 연동, 접근 제한, 추방 기능, NEW 배지 처리까지 구현

---

### 주요 변경 사항
1️⃣ **AuthContext + GroupMemberContext 연동**
- 로그인한 사용자 정보(user)와 group_members 데이터 연동
- isHost / isMember 상태값을 기반으로 UI 제어

2️⃣ **접근 제한 처리**
- 비로그인 시 `/login`으로 리다이렉트
- 비멤버는 접근 불가 메시지 출력

3️⃣ **모임장 전용 추방 기능**
- 호스트만 드롭다운(…) 버튼 및 추방 기능 활성화
- Supabase `update group_members set member_status='left'` 로 처리
- member_role이 `host`인 경우 추방 불가

4️⃣ **DB 연동 (Mock 제거)**
- `fetchMembers(groupId)`로 Supabase에서 실제 멤버 데이터 조회
- user_profiles 조인으로 닉네임 및 아바타 표시

5️⃣ **NEW 배지 처리**
- 가입 3일 이내 멤버에게 NEW 배지 표시
- NEW 배지는 모임장만 볼 수 있도록 조건 추가

---

### Review Notes
- 추방 시 DB 반영 및 UI 반영 정상 확인 필요
- 로그인 상태에 따라 접근 제한 정상 동작 확인
- NEW 배지 3일 조건 및 모임장만 표시 여부 확인
