### PR TITLE
[docs] 관리자 페이지 문의내역 연동 완

### DIFF
--- a/src/admin/AdminInquiryList.tsx
+++ b/src/admin/AdminInquiryList.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect } from 'react';
+import LoadingSpinner from '../components/common/LoadingSpinner';
+import type { inquirie } from '../types/inquiriesType';
+import { supabase } from '../lib/supabase';
+
+// user_profiles에서 필요한 필드만 정의
+interface UserProfile {
+  name: string;
+  email: string;
+}
+
+// Supabase에서 가져올 조인 데이터 타입
+interface InquiryWithProfile extends inquirie {
+  user_profiles: UserProfile | null;
+  user_name: string; // 평탄화 후 추가
+  user_email: string;
+}
+
+function AdminInquiryList() {
+  const [inquiries, setInquiries] = useState<InquiryWithProfile[]>([]);
+  const [selectedInquiry, setSelectedInquiry] = useState<InquiryWithProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [answer, setAnswer] = useState('');
+
+  // 문의 목록 불러오기
+  const fetchInquiries = async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('user_inquiries')
+      .select(
+        `
+        inquiry_id,
+        inquiry_main_type,
+        inquiry_sub_type,
+        inquiry_detail,
+        inquiry_status,
+        inquiry_answer,
+        inquiry_file_urls,
+        inquiry_created_at,
+        inquiry_answered_at,
+        user_profiles(name, email)
+      `,
+      )
+      .eq('inquiry_status', 'pending')
+      .order('inquiry_created_at', { ascending: false });
+
+    if (error) {
+      console.error('❌ 문의 불러오기 오류:', error);
+    } else if (data) {
+      // Supabase에서 관계로 가져온 user_profiles 정보 평탄화
+      const formatted = (data as any[]).map(item => ({
+        ...item,
+        user_name: item.user_profiles?.name ?? '알 수 없음',
+        user_email: item.user_profiles?.email ?? '-',
+      }));
+      setInquiries(formatted);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchInquiries();
+  }, []);
+
+  // 문의 보기
+  const handleSelect = (inquiry: InquiryWithProfile) => {
+    setSelectedInquiry(inquiry);
+    setAnswer(inquiry.inquiry_answer || '');
+  };
+
+  // 답변 저장 -> db 업데이트
+  const handleSubmitAnswer = async () => {
+    if (!selectedInquiry) return;
+    if (!answer.trim()) {
+      alert('답변을 입력하세요.');
+      return;
+    }
+
+    const { error } = await supabase
+      .from('user_inquiries')
+      .update({
+        inquiry_answer: answer,
+        inquiry_status: 'answered',
+        inquiry_answered_at: new Date().toISOString(),
+      })
+      .eq('inquiry_id', selectedInquiry.inquiry_id);
+
+    if (error) {
+      console.error('❌ 답변 저장 오류:', error);
+      alert('답변 저장 중 오류가 발생했습니다.');
+      return;
+    }
+
+    alert(' 답변이 저장되었습니다.');
+
+    await fetchInquiries();
+    setSelectedInquiry(null);
+  };
+
+  return (
+    <div className="mx-auto">
+      {/* 목록 */}
+      <div className="border border-gray-300 rounded-[5px]">
+        <div
+          className="grid text-center py-3 text-md font-semibold text-gray-400 border-b border-gray-200"
+          style={{ gridTemplateColumns: '1fr 1fr 1.5fr 2fr 1fr 1fr' }}
+        >
+          <div>문의 일자</div>
+          <div>유저 이름</div>
+          <div>문의 유형</div>
+          <div>내용</div>
+          <div>상태</div>
+          <div>상세보기</div>
+        </div>
+
+        {/* 목록 내용 */}
+        {loading ? (
+          <LoadingSpinner />
+        ) : inquiries.length === 0 ? (
+          <div className="text-center py-10 text-gray-300 text-lg">문의 내역이 없습니다.</div>
+        ) : (
+          inquiries.map((item, index) => (
+            <div
+              key={item.inquiry_id}
+              className={`grid items-center text-center py-3 text-md text-gray-200 ${
+                index === inquiries.length - 1 ? '' : 'border-b border-gray-200'
+              }`}
+              style={{ gridTemplateColumns: '1fr 1fr 1.5fr 2fr 1fr 1fr' }}
+            >
+              <div>{new Date(item.inquiry_created_at).toLocaleDateString()}</div>
+              <div className="font-medium text-gray-400">
+                {item.user_profiles?.name ?? '알 수 없음'}
+              </div>
+              <div className="font-medium text-gray-400 text-sm">
+                <b>{item.inquiry_main_type}</b>
+                <br />
+                <span className=" text-gray-200  whitespace-nowrap">{item.inquiry_sub_type}</span>
+              </div>
+              <div className="truncate">{item.inquiry_detail}</div>
+              <div
+                className={`${
+                  item.inquiry_status === 'answered'
+                    ? 'text-green-500 font-semibold'
+                    : 'text-gray-400'
+                }`}
+              >
+                {item.inquiry_status === 'answered' ? '답변완료' : '대기중'}
+              </div>
+              <button
+                onClick={() => handleSelect(item)}
+                className="text-brand font-semibold hover:underline"
+              >
+                보기
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* 상세 보기 */}
+      {selectedInquiry && (
+        <div className="mt-10 border border-gray-300 rounded-[5px] p-8">
+          <div className="text-brand font-semibold text-xl mb-5">문의 상세보기</div>
+
+          <div className="mb-4 pl-4">
+            <div className="flex gap-5 mb-2">
+              <span className="text-gray-400 font-bold w-[80px]">이름</span>
+              <span>{selectedInquiry.user_name}</span>
+            </div>
+            <div className="flex gap-5 mb-2">
+              <span className="text-gray-400 font-bold w-[80px]">이메일</span>
+              <span>{selectedInquiry.user_email}</span>
+            </div>
+            <div className="flex gap-5 mb-2">
+              <span className="text-gray-400 font-bold w-[80px]">문의 유형</span>
+              <span>
+                {selectedInquiry.inquiry_main_type} / {selectedInquiry.inquiry_sub_type}
+              </span>
+            </div>
+            <div className="border-t border-gray-300 my-6" />
+
+            <div className="flex flex-1 gap-5 mb-2 items-start">
+              <span className="text-gray-400 font-bold w-[80px] shrink-0">문의 내용</span>
+              <span className="text-gray-700 whitespace-pre-line break-words flex-1">
+                {selectedInquiry.inquiry_detail}
+              </span>
+            </div>
+
+            <div className="flex flex-1 gap-5 mb-2 items-start">
+              <span className="text-gray-400 font-bold w-[80px] shrink-0">첨부파일</span>
+              <span className="flex-1">
+                {/* 첨부된 파일이 있다면 보여주기 */}
+                {(() => {
+                  const files: { path: string; originalName: string }[] = [];
+
+                  if (selectedInquiry.inquiry_file_urls) {
+                    try {
+                      let parsed: any = selectedInquiry.inquiry_file_urls;
+
+                      // 문자열이면 JSON.parse
+                      if (typeof parsed === 'string') {
+                        parsed = JSON.parse(parsed);
+                      }
+
+                      // 배열 안에 문자열(JSON 문자열) 있으면 다시 파싱
+                      if (Array.isArray(parsed)) {
+                        parsed = parsed
+                          .map(item => {
+                            if (typeof item === 'string') {
+                              try {
+                                return JSON.parse(item);
+                              } catch {
+                                return null;
+                              }
+                            }
+                            return item;
+                          })
+                          .filter((item): item is { path: string; originalName: string } => {
+                            // null 제거 & 타입 가드
+                            return (
+                              item &&
+                              typeof item.path === 'string' &&
+                              typeof item.originalName === 'string'
+                            );
+                          });
+                      }
+
+                      files.push(...(Array.isArray(parsed) ? parsed : []));
+                    } catch (e) {
+                      console.warn('파일 파싱 오류:', e);
+                    }
+                  }
+
+                  return files.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {files.slice(0, 2).map((file, idx) => (
+                        <a
+                          key={idx}
+                          href={`https://eetunrwteziztszaezhd.supabase.co/storage/v1/object/public/inquiry-images/${file.path}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center bg-white border border-gray-300 p-1 rounded-[5px] text-sm text-gray-700"
+                        >
+                          <img src="/images/file_blue.svg" alt="파일" className="mr-1 w-4 h-4" />
+                          <span className="truncate max-w-[200px]">{file.originalName}</span>
+                        </a>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-gray-400 text-sm">첨부파일 없음</div>
+                  );
+                })()}
+              </span>
+            </div>
+          </div>
+
+          <div className="mb-4 pl-4">
+            <div className="border-t border-gray-300 my-6" />
+            <div className="text-gray-400 font-bold mb-4">관리자 답변</div>
+            <textarea
+              className="w-full resize-none h-[120px] border border-gray-300 rounded-[8px] p-3 bg-transparent text-gray-200"
+              value={answer}
+              onChange={e => setAnswer(e.target.value)}
+              placeholder="답변을 입력하세요..."
+            />
+          </div>
+
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={() => setSelectedInquiry(null)}
+              className="px-5 py-2 border border-brand text-brand rounded-[5px]"
+            >
+              닫기
+            </button>
+            <button
+              onClick={handleSubmitAnswer}
+              className="px-5 py-2 bg-brand text-white rounded-[5px]"
+            >
+              답변 저장
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AdminInquiryList;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import PendingGroupsList from '../admin/PendingGroupsList';
 import { AnimatePresence, motion } from 'framer-motion';
+import AdminInquiryList from '../admin/AdminInquiryList';
 
 function Admin() {
   const tabs = useMemo(
@@ -15,7 +16,11 @@ function Admin() {
       },
       {
         label: '문의 내역 목록',
-        content: <div>문의내역 컴포넌트 작성 예정</div>,
+        content: (
+          <div>
+            <AdminInquiryList />
+          </div>
+        ),
       },
       {
         label: '회원 탈퇴 목록',
@@ -25,7 +30,16 @@ function Admin() {
     [],
   );
 
-  const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  const [selectedTab, setSelectedTab] = useState(() => {
+    const saved = localStorage.getItem('adminSelectedTab');
+    return tabs.find(tab => tab.label === saved) || tabs[0];
+  });
+
+  // 탭 선택후 새로고침 하면 돌아가는거 방지
+  const handleTabClick = (tab: (typeof tabs)[0]) => {
+    setSelectedTab(tab);
+    localStorage.setItem('adminSelectedTab', tab.label);
+  };
 
   // underline 위치/너비 측정용
   const listRef = useRef<HTMLUListElement | null>(null);
@@ -62,7 +76,7 @@ function Admin() {
                 key={tab.label}
                 ref={el => (tabRefs.current[i] = el)}
                 className={`cursor-pointer pt-1 ${tab.label === selectedTab.label ? 'text-brand text-lg font-bold' : 'text-gray-400 text-lg font-medium hover:text-brand'}`}
-                onClick={() => setSelectedTab(tab)}
+                onClick={() => handleTabClick(tab)}
               >
                 {tab.label}
               </li>

--- a/src/pages/MyInquiriesPage.tsx
+++ b/src/pages/MyInquiriesPage.tsx
@@ -240,7 +240,7 @@ function MyInquiriesPage() {
                   <div
                     className={`text-md ${
                       item.inquiry_status === 'answered'
-                        ? 'text-gray-400 font-semibold'
+                        ? 'text-brand font-semibold'
                         : 'text-gray-200 font-medium'
                     }`}
                   >


### PR DESCRIPTION
1. 관리자 페이지 관련

문의 내역(AdminInquiryList)
문의 상태가 답변 완료인 항목은 목록에서 제외하고, 대기중인 항목만 표시하도록 개선
상세보기에서 첨부파일 표시 기능 추가
파일이 존재하면 링크로 표시
파일이 없으면 "첨부파일 없음" 표시하도록 3항 연산자 적용
답변 textarea 높이 고정(resize-none) 적용

Supabase 데이터 평탄화 작업
user_profiles에서 name과 email 추출 후 user_name, user_email로 저장
답변 저장 시 RLS 정책에 맞게 inquiry_status 업데이트

Admin 페이지 탭 기능 개선
AnimatePresence와 motion으로 탭 전환 애니메이션 적용
Admin 페이지 탭 새로고침 시 선택 상태 유지 기능 구현

2. Supabase RLS(Row Level Security) 정책

user_inquiries 테이블 RLS 활성화
관리자 이메일 기반 접근 정책 수정
SELECT 정책: 여러 관리자 이메일 허용 (IN 구문 적용)
UPDATE 정책: 여러 관리자 이메일 허용 (IN 구문 적용)
기존 정책 삭제 후 재생성하여 충돌 방지
Supabase RLS 정책 테스트 및 다중 관리자 적용 확인

3. 코드 개선 및 버그 수정

JSON.parse 오류 처리 개선
첨부파일 배열이 string[] 혹은 null일 경우 안전하게 파싱
TypeScript 타입 오류 처리(Json -> { path: string; originalName: string } 변환)
목록 및 상세보기 UI/UX 개선
목록에서 유저 이름, 상태, 유형, 내용 표시
상세보기에서 첨부파일, 문의 내용, 답변 영역 명확히 구분

4. 기타

모임 생성 신청 목록, 문의 내역 목록, 회원 탈퇴 목록 탭 구조 생성 및 UI 배치
tab underline 위치 측정 로직 useLayoutEffect 적용
Framer Motion으로 탭 전환 시 애니메이션 처리

