### PR TITLE
[fix] Supabase .or() 구문 오류로 인한 400 Bad Request 해결 및 채팅방 조회 로직 안정화

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,8 +97,23 @@ const Header: React.FC = () => {
           filter: `user_id=eq.${user.id}`,
         },
         (payload) => {
-          console.log("[Header 🔴 notifications 이벤트]", payload.new);
-          setUnreadCount((prev) => prev + 1);
+          const n = payload.new;
+          console.log("[Header 🔴 notifications 이벤트]", n);
+
+          // 1️⃣ chat 타입 포함 — 모든 알림 타입 허용
+          if (
+            [
+              "chat",
+              "review_like",
+              "post_like",
+              "group_approved",
+              "group_request",
+              "inquiry_new",
+              "inquiry_reply",
+            ].includes(n.type)
+          ) {
+            setUnreadCount((prev) => prev + 1);
+          }
         },
       )
       .subscribe();

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase';
+import { supabase } from "./supabase";
 
 /**
  * 알림 생성 공통 유틸
@@ -19,14 +19,20 @@ export async function insertNotification({
   targetId = null,
 }: {
   userId: string;
-  type: 'review_like' | 'post_like' | 'inquiry_new' | 'inquiry_reply' | 'group_approved';
+  type:
+    | "review_like"
+    | "post_like"
+    | "inquiry_new"
+    | "inquiry_reply"
+    | "group_approved"
+    | "chat";
   title: string;
   message: string;
   groupId?: string | null;
   targetId?: string | null;
 }) {
   if (!userId) return;
-  const { error } = await supabase.rpc('create_notification', {
+  const { error } = await supabase.rpc("create_notification", {
     p_user_id: userId,
     p_type: type,
     p_title: title,
@@ -34,5 +40,6 @@ export async function insertNotification({
     p_group_id: groupId,
     p_target_id: targetId,
   });
-  if (error) console.error('[insertNotification] 알림 전송 실패:', error.message);
+  if (error)
+    console.error("[insertNotification] 알림 전송 실패:", error.message);
 }


### PR DESCRIPTION
## 🔍 변경 내용
- Supabase .or() 사용 시 발생하던 400 (Bad Request) 에러 해결
- findOrCreateChat() 로직 수정: JS 단에서 host/member 양방향 필터링 처리
- direct_chats 조회 안정화 및 불필요한 REST 에러 제거
- RPC rejoin_counterpart와 연동하여 상대 참가자 자동 추가 보장

## ✅ 결과
- 채팅방 생성 및 조회 정상 작동
- 상대방이 채팅방 진입 전이라도 메시지 및 알림 정상 표시
- Header/Panel 양쪽에서 실시간 반영 확인