### PR TITLE
[feat] Header 및 CategorySidebar에 활성화 상태 시각 피드백 추가

### DIFF
--- a/src/components/CategoryMenuSidebar.tsx
+++ b/src/components/CategoryMenuSidebar.tsx
@@ -47,8 +47,8 @@ function CategoryMenuSidebar() {
     const pathParts = location.pathname.split("/").filter(Boolean);
     const slug = pathParts[pathParts.length - 1];
 
-    // 전체보기 처리
-    if (slug === "all") {
+    // 전체보기
+    if (location.pathname === "/grouplist" || slug === "all") {
       setActiveMain("전체보기");
       setActiveSub("");
       setOpenCategory("");

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { Session, User } from "@supabase/supabase-js";
 import { getProfile } from "../lib/profile";
 import { supabase } from "../lib/supabase";
@@ -19,6 +19,9 @@ const Header: React.FC = () => {
   const [unreadCount, setUnreadCount] = useState<number>(0);
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const isActive = (path: string) => location.pathname.startsWith(path);
 
   // 사용자 세션 초기화
   const initUserSession = async (): Promise<void> => {
@@ -98,9 +101,9 @@ const Header: React.FC = () => {
         },
         (payload) => {
           const n = payload.new;
-          console.log("[Header 🔴 notifications 이벤트]", n);
+          console.log("[Header notifications 이벤트]", n);
 
-          // 1️⃣ chat 타입 포함 — 모든 알림 타입 허용
+          // chat 타입 포함 — 모든 알림 타입 허용
           if (
             [
               "chat",
@@ -182,16 +185,36 @@ const Header: React.FC = () => {
           {/* 메뉴 */}
           <div className="hidden md:flex items-center gap-9">
             <nav className="flex gap-6 text-gray-700">
-              <Link to="/groupmanager" className="font-bold hover:text-brand">
+              <Link
+                to="/groupmanager"
+                className={`font-bold hover:text-brand ${
+                  isActive("/groupmanager") ? "text-brand" : ""
+                }`}
+              >
                 모임관리
               </Link>
-              <Link to="/reviews" className="font-bold hover:text-brand">
+              <Link
+                to="/reviews"
+                className={`font-bold hover:text-brand ${
+                  isActive("/reviews") ? "text-brand" : ""
+                }`}
+              >
                 후기리뷰
               </Link>
-              <Link to="/grouplist" className="font-bold hover:text-brand">
+              <Link
+                to="/grouplist"
+                className={`font-bold hover:text-brand ${
+                  isActive("/grouplist") ? "text-brand" : ""
+                }`}
+              >
                 모임리스트
               </Link>
-              <Link to="/mypage" className="font-bold hover:text-brand">
+              <Link
+                to="/mypage"
+                className={`font-bold hover:text-brand ${
+                  isActive("/mypage") ? "text-brand" : ""
+                }`}
+              >
                 마이페이지
               </Link>
             </nav>
@@ -221,7 +244,7 @@ const Header: React.FC = () => {
                 {/* 로그아웃 */}
                 <button
                   onClick={handleLogout}
-                  className="font-bold text-sm border px-3 py-1.5 rounded-lg border-brand text-brand hover:bg-blue-600 hover:text-white hover:border-blue-600 transition"
+                  className="font-bold text-sm border px-3 py-1.5 rounded-sm border-brand text-brand hover:bg-blue-600 hover:text-white hover:border-blue-600 transition"
                 >
                   로그아웃
                 </button>
@@ -323,7 +346,7 @@ const Header: React.FC = () => {
               <Link
                 to="/login"
                 onClick={() => setIsMenuOpen(false)}
-                className="font-bold text-sm px-3 py-2 rounded-lg bg-brand text-white hover:bg-blue-600"
+                className="font-bold text-sm px-3 py-2 rounded-sm bg-brand text-white hover:bg-blue-600"
               >
                 로그인
               </Link>

--- a/src/components/common/InfiniteScrollList.tsx
+++ b/src/components/common/InfiniteScrollList.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, useRef } from "react";
+
+interface InfiniteScrollListProps<T> {
+  items: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+  initialCount?: number;
+  loadMoreCount?: number;
+}
+
+function InfiniteScrollList<T>({
+  items,
+  renderItem,
+  initialCount = 13,
+  loadMoreCount = 5,
+}: InfiniteScrollListProps<T>) {
+  const [visibleCount, setVisibleCount] = useState(initialCount);
+  const [isFetching, setIsFetching] = useState(false);
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const visibleItems = items.slice(0, visibleCount);
+  const hasMore = visibleCount < items.length;
+
+  // 스크롤 감지
+  useEffect(() => {
+    if (!hasMore || isFetching) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setIsFetching(true);
+        setTimeout(() => {
+          setVisibleCount((prev) => prev + loadMoreCount);
+          setIsFetching(false);
+        }, 500); // 약간의 로딩 텀 (UX 개선)
+      }
+    });
+
+    const target = observerRef.current;
+    if (target) observer.observe(target);
+
+    return () => {
+      if (target) observer.unobserve(target);
+    };
+  }, [hasMore, isFetching, loadMoreCount]);
+
+  return (
+    <div className="space-y-4">
+      {visibleItems.map((item, index) => renderItem(item, index))}
+
+      {/* 감지용 더미 엘리먼트 */}
+      {hasMore && <div ref={observerRef} className="h-10" />}
+
+      {/* 로딩 표시 */}
+      {isFetching && (
+        <p className="text-center text-sm text-gray-400">불러오는 중...</p>
+      )}
+
+      {/* 끝 표시 */}
+      {!hasMore && items.length > 0 && (
+        <div className="pt-[107px] flex items-center">
+          <div className="flex-1 border-t border-[#8C8C8C]" />
+          <span className="mx-4 text-sm text-[#8C8C8C] whitespace-nowrap">
+            모든 항목을 불러왔습니다
+          </span>
+          <div className="flex-1 border-t border-[#8C8C8C]" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default InfiniteScrollList;

--- a/src/components/layout/GroupListLayout.tsx
+++ b/src/components/layout/GroupListLayout.tsx
@@ -9,6 +9,7 @@ import GroupListCard from "../common/GroupListCard";
 import GroupSearchResults from "../search/GroupSearchResults";
 import { useSearchParams } from "react-router-dom";
 import LoadingSpinner from "../common/LoadingSpinner";
+import InfiniteScrollList from "../common/InfiniteScrollList";
 
 type GroupListLayoutProps = {
   mainCategory: string;
@@ -139,36 +140,26 @@ function GroupListLayout({
                 />
               </div>
 
-              {/* 카드 리스트 */}
-              <div className="space-y-4">
-                {loading ? (
-                  <LoadingSpinner />
-                ) : displayedGroups.length === 0 ? (
-                  <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.4 }}
-                    className="flex flex-col justify-center items-center h-60 bg-gray-50"
-                  >
-                    <motion.p
-                      className="text-lg font-semibold text-gray-600"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{ delay: 0.2 }}
-                    >
-                      현재 등록된 모임이 없습니다
-                    </motion.p>
-                    <motion.p
-                      className="text-sm text-gray-400 mt-2"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      transition={{ delay: 0.4 }}
-                    >
-                      새로운 모임을 만들고 친구들과 활동을 시작해보세요!
-                    </motion.p>
-                  </motion.div>
-                ) : (
-                  displayedGroups.map((group) => (
+              {loading ? (
+                <LoadingSpinner />
+              ) : displayedGroups.length === 0 ? (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4 }}
+                  className="flex flex-col justify-center items-center h-60 bg-gray-50"
+                >
+                  <p className="text-lg font-semibold text-gray-600">
+                    현재 등록된 모임이 없습니다
+                  </p>
+                  <p className="text-sm text-gray-400 mt-2">
+                    새로운 모임을 만들고 친구들과 활동을 시작해보세요!
+                  </p>
+                </motion.div>
+              ) : (
+                <InfiniteScrollList
+                  items={displayedGroups}
+                  renderItem={(group) => (
                     <GroupListCard
                       key={group.group_id}
                       group_id={group.group_id}
@@ -190,19 +181,9 @@ function GroupListLayout({
                       group_start_day={group.group_start_day}
                       group_end_day={group.group_end_day}
                     />
-                  ))
-                )}
-
-                {displayedGroups.length > 0 && (
-                  <div className="pt-[107px] flex items-center">
-                    <div className="flex-1 border-t border-[#8C8C8C]" />
-                    <span className="mx-4 text-sm text-[#8C8C8C] whitespace-nowrap">
-                      모든 항목을 불러왔습니다
-                    </span>
-                    <div className="flex-1 border-t border-[#8C8C8C]" />
-                  </div>
-                )}
-              </div>
+                  )}
+                />
+              )}
             </section>
           </>
         )}


### PR DESCRIPTION
### 작업 내용
- Header에 현재 경로에 따른 활성 메뉴 스타일(text-brand) 적용
  - `/groupmanager`, `/reviews`, `/grouplist`, `/mypage` 방문 시 해당 탭 파란색 표시
- CategoryMenuSidebar에서 `/grouplist` 접속 시 '전체보기' 기본 활성화 처리
  - `/grouplist/all`과 동일하게 파란색(text-brand) 유지

### 변경 이유
- 사용자가 현재 위치한 페이지를 직관적으로 인식할 수 있도록 UI 개선
- 모임리스트 진입 시 '전체보기' 탭이 기본 선택되도록 UX 일관성 확보

### 테스트 항목
- [x] Header 메뉴 클릭 시 해당 탭 색상 변경
- [x] `/grouplist` 접근 시 전체보기 자동 파란색 표시
- [x] 다른 카테고리 진입 시 정상적으로 색상 변경